### PR TITLE
fix containerized api call

### DIFF
--- a/src/lib/api/rest/api.ts
+++ b/src/lib/api/rest/api.ts
@@ -3,7 +3,7 @@ import type { DiscoverGraph } from "$lib/models/DiscoverGraph";
 //import { env } from 'node:process';
 
 //const base = env.API_ENDPOINT || 'http://localhost:8080/api/v1';
-const base = 'http://localhost:8080/api/v1';
+const base = '/api/v1';
 
 export async function getInfo(owner: string, repoName: string): Promise<pbReadInfoResponse> {
     const res = await fetch(`${base}/info/${owner}/${repoName}`, { method: 'GET'});


### PR DESCRIPTION
Use the `/api/v1` address for containerized deployment of frontend bundled with `egh-api`.